### PR TITLE
Improved handling of unknown locations

### DIFF
--- a/resources/SimpleMap_Map.js
+++ b/resources/SimpleMap_Map.js
@@ -202,8 +202,12 @@ SimpleMap.prototype.sync = function (update) {
 
 	// Update address / lat / lng based off marker location
 	this.geo(pos, function (loc) {
-		self.address.value = loc.formatted_address;
-		self.inputs.address.value = loc.formatted_address;
+		// if loc, set address to formatted_location, else to postion
+		var address = loc ? loc.formatted_address : pos.lat() + ", " + pos.lng();
+
+		// update address value
+		self.address.value = address;
+		self.inputs.address.value = address;
 	});
 
 	if (update) return this.update(pos.lat, pos.lng, true);
@@ -215,15 +219,22 @@ SimpleMap.prototype.geo = function (latLng, callback) {
 	if (!latLng.lat) attr = {'address': latLng};
 
 	this.geocoder.geocode(attr, function (results, status) {
-		if (status !== google.maps.GeocoderStatus.OK) {
-			SimpleMap.Fail('Geocoder failed as a result of', status);
-			return;
-		} else if (!results[0]) {
-			SimpleMap.Fail('No results found!');
+		var loc;
+
+		// if location available, set loc to first result
+		if (status == google.maps.GeocoderStatus.OK) {
+			loc = results[0];
+
+		// if zero_results, set loc to false
+		} else if (status == google.maps.GeocoderStatus.ZERO_RESULTS) {
+			loc = false;
+
+		// else return error message
+		} else {
+			SimpleMap.Fail('Geocoder failed as a result of ' + status);
 			return;
 		}
 
-		var loc = results[0];
 		callback(loc);
 	});
 };


### PR DESCRIPTION
When a marker is put in a location that gives `ZERO_RESULTS`, the
coordinates of the marker will be displayed in the address bar.
- `geo()` now checks for status `ZERO_RESULTS` in addition to `OK`
- When `geocode()` returns `OK`, the `loc` will be set to the first
result
- When `geocode()` returns `ZERO_RESULTS`, the `loc` will be set to the
false
- When `geocode()` returns anything else, the error will be logged
- When updating the address, a `loc` set to `false` will use the `pos`
variable instead