### PR TITLE
Support for Feed Me 2.x

### DIFF
--- a/SimpleMapPlugin.php
+++ b/SimpleMapPlugin.php
@@ -66,4 +66,20 @@ class SimpleMapPlugin extends BasePlugin {
 		));
 	}
 
+	public function init()
+	{
+		Craft::import('plugins.simplemap.integrations.feedme.fields.SimpleMap_MapFeedMeFieldType');
+	}
+
+
+	// =========================================================================== //
+	// For compatibility with Feed Me plugin (v2.x)
+
+	public function registerFeedMeFieldTypes()
+	{
+		return array(
+			new SimpleMap_MapFeedMeFieldType(),
+		);
+	}
+
 }

--- a/integrations/feedme/fields/SimpleMap_MapFeedMeFieldType.php
+++ b/integrations/feedme/fields/SimpleMap_MapFeedMeFieldType.php
@@ -31,7 +31,16 @@ class SimpleMap_MapFeedMeFieldType extends BaseFeedMeFieldType
         
         // Check for empty Address
         if (!isset($content['address'])) {
-            $content['address'] = $this->_getAddressFromLatLng($content['lat'], $content['lng']);
+            $addressInfo = $this->_getAddressFromLatLng($content['lat'], $content['lng']);
+            $content['address'] = $addressInfo['formatted_address'];
+
+            // Populate address parts
+            if (isset($addressInfo['address_components'])) {
+                foreach ($addressInfo['address_components'] as $component) {
+                    $content['parts'][$component['types'][0]] = $component['long_name'];
+                    $content['parts'][$component['types'][0] . '_short'] = $component['short_name'];
+                }
+            }
         }
 
         // Check for empty Longitude/Latitude
@@ -92,7 +101,7 @@ class SimpleMap_MapFeedMeFieldType extends BaseFeedMeFieldType
 
         if (empty($resp['results'])) return null;
 
-        return $resp['results'][0]['formatted_address'];
+        return $resp['results'][0];
     }
     
 }

--- a/integrations/feedme/fields/SimpleMap_MapFeedMeFieldType.php
+++ b/integrations/feedme/fields/SimpleMap_MapFeedMeFieldType.php
@@ -1,0 +1,98 @@
+<?php
+namespace Craft;
+
+class SimpleMap_MapFeedMeFieldType extends BaseFeedMeFieldType
+{
+    // Templates
+    // =========================================================================
+
+    public function getMappingTemplate()
+    {
+        return 'simplemap/_integrations/feedme/fields/simplemap_map';
+    }
+    
+
+
+    // Public Methods
+    // =========================================================================
+
+    public function prepFieldData($element, $field, $data, $handle, $options)
+    {
+        // Initialize content array
+        $content = array();
+
+        foreach ($data as $subfieldHandle => $subfieldData) {
+            // Set value to subfield of correct address array
+            $content[$subfieldHandle] = $subfieldData;
+        }
+
+        // In order to full-fill any empty gaps in data (lng/lat/address), we check to see if we have any data missing
+        // then, request that data through Google's geocoding API - making for a hands-free import. 
+        
+        // Check for empty Address
+        if (!isset($content['address'])) {
+            $content['address'] = $this->_getAddressFromLatLng($content['lat'], $content['lng']);
+        }
+
+        // Check for empty Longitude/Latitude
+        if (!isset($content['lat']) || !isset($content['lng'])) {
+            $latlng = $this->_getLatLngFromAddress($content['address']);
+            $content['lat'] = $latlng['lat'];
+            $content['lng'] = $latlng['lng'];
+        }
+
+        // Return data
+        return $content;
+    }
+
+
+
+
+    // Private Methods
+    // =========================================================================
+
+    private function _getLatLngFromAddress($address)
+    {
+        $this->settings = craft()->plugins->getPlugin('SimpleMap')->getSettings();
+
+        if (!$this->settings['browserApiKey']) return null;
+
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . rawurlencode($address)
+            . '&key=' . $this->settings['browserApiKey'];
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $resp = json_decode(curl_exec($ch), true);
+
+        if (array_key_exists('error_message', $resp) && $resp['error_message'])
+            SimpleMapPlugin::log($resp['error_message'], LogLevel::Error);
+
+        if (empty($resp['results'])) return null;
+
+        return $resp['results'][0]['geometry']['location'];
+    }
+
+    private function _getAddressFromLatLng($lat, $lng)
+    {
+        $this->settings = craft()->plugins->getPlugin('SimpleMap')->getSettings();
+
+        if (!$this->settings['browserApiKey']) return null;
+
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' . rawurlencode($lat) . ',' . rawurlencode($lng)
+            . '&key=' . $this->settings['browserApiKey'];
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $resp = json_decode(curl_exec($ch), true);
+
+        if (array_key_exists('error_message', $resp) && $resp['error_message'])
+            SimpleMapPlugin::log($resp['error_message'], LogLevel::Error);
+
+        if (empty($resp['results'])) return null;
+
+        return $resp['results'][0]['formatted_address'];
+    }
+    
+}

--- a/templates/_integrations/feedme/fields/simplemap_map.twig
+++ b/templates/_integrations/feedme/fields/simplemap_map.twig
@@ -1,0 +1,38 @@
+{% set simpleMapSubfields = ['lat','lng','zoom','address'] %}
+
+{% for subfield in simpleMapSubfields %}
+    {% set optionLabel  = field.name ~ ' (' ~ subfield ~ ')' %}
+    {% set optionLabelHandle = field.handle ~ '[' ~ subfield ~ ']' %}
+    {% set optionHandle = field.handle ~ '--' ~ subfield %}
+
+    <tr>
+        <td class="col-field">
+            <div class="field">
+                <div class="heading">
+                    <label>{{ optionLabel }}</label>
+
+                    <div class="instructions">
+                        <code>{{ optionLabelHandle }}</code>
+                    </div>
+                </div>
+            </div>
+        </td>
+
+        <td class="col-map">
+            {% namespace 'fieldMapping' %}
+                {{ forms.selectField({
+                    id: optionHandle,
+                    name: optionHandle,
+                    value: feed.fieldMapping[optionHandle] ?? '',
+                    options: feedData,
+                }) }}
+            {% endnamespace %}
+        </td>
+
+        <td class="col-default">
+            <div class="default-fields">
+                
+            </div>
+        </td>
+    </tr>
+{% endfor %}


### PR DESCRIPTION
Hi there, 

Just thought to create a PR for the issue [#22](https://github.com/ethercreative/simplemap/issues/22).

I'm not sure if you plan on implementing this via JS (checking if an address value is empty, but valid lng/lat values), but this is probably a more case-specific fix.

Please also refer to the [Feed Me 2.0 Field Types Docs](http://sgroup.com.au/plugins/feedme/developers/field-types). You're more than welcome to shift things to suite your needs.

So - what this PR does it enable support for Feed Me 2. When mapping data to a SimpleMap field, you'll get the following 4 options:

![screen shot 2016-12-21 at 12 17 34 pm](https://cloud.githubusercontent.com/assets/1221575/21374010/7b74967a-c777-11e6-98b4-14409b9e3f58.png)

In addition - the import process (implemented in `SimpleMap_MapFeedMeFieldType.php`), will actually check data for `address`, `lng`, and `lat`, and fill in any missing information. This is important where other systems might only provide one or the other values.