### PR TITLE
Disable scrollwheel on maps in the control panel

### DIFF
--- a/simplemap/resources/SimpleMap_Map.js
+++ b/simplemap/resources/SimpleMap_Map.js
@@ -146,6 +146,7 @@ SimpleMap.prototype.setupMap = function () {
 	// Create Map
 	this.map = new google.maps.Map(this.mapEl, {
 		zoom:		this.settings.zoom,
+		scrollwheel:    false,
 		center:		new google.maps.LatLng(this.settings.lat, this.settings.lng),
 		mapTypeId:	google.maps.MapTypeId.ROADMAP
 	});


### PR DESCRIPTION
It's way too easy to "ruin" a saved map zoom when scrolling down an entry in the control panel. Disable the scrollwheel. This is in relation to this comment: https://github.com/ethercreative/simplemap/issues/26#issuecomment-278468003