### PR TITLE
Fix #92

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+README.md       export-ignore
+releases.json   export-ignore
+/resources      export-ignore
+.gitignore      export-ignore
+.gitattributes  export-ignore

--- a/simplemap/services/SimpleMapService.php
+++ b/simplemap/services/SimpleMapService.php
@@ -120,10 +120,10 @@ class SimpleMapService extends BaseApplicationComponent {
 	{
 		$owner = $fieldType->element;
 		$field = $fieldType->model;
-		$content = $fieldType->element->getContent();
+		$content = $fieldType->element;
 
 		$handle = $field->handle;
-		$data = $content->getAttribute($handle);
+		$data = $content[$field->handle]->getAttributes();
 
 		if (
 			!array_key_exists('lat', $data)


### PR DESCRIPTION
This fixes an issue where the `ContentModel` of an entry was being used to pull data for validation. Since Simple Map uses a separate table for its storage, the field will always be `null`, and of course you can't check the keys of a `null` value, so PHP has a meltdown.

This commit updates the service method so Craft fetches the field data via relation, and simple provides it in the same format the existing code expects it in. (An `array` of field data.)