### PR TITLE
Fix typo on override message

### DIFF
--- a/simplemap/templates/plugin-settings.twig
+++ b/simplemap/templates/plugin-settings.twig
@@ -21,5 +21,5 @@
 	type: 'text',
 	required: false,
 	readonly: configFileSettings.serverApiKey ? true : false,
-	warning: configFileSettings.serverApiKey ? "This is being overridden by the browserApiKey config setting." : ''
+	warning: configFileSettings.serverApiKey ? "This is being overridden by the serverApiKey config setting." : ''
 }) }}


### PR DESCRIPTION
Not sure if your still accepting changes for the v2 branch, but if you are:

Changes proposed in this pull request:

* Fix typo on plugin settings, duplicated variable name for unrestricted server API key.