### PR TITLE
Upgrade fix for craft 2 to craft 3

### DIFF
--- a/src/migrations/m190226_143809_craft3_upgrade.php
+++ b/src/migrations/m190226_143809_craft3_upgrade.php
@@ -39,7 +39,7 @@ class m190226_143809_craft3_upgrade extends Migration
     public function safeUp()
     {
         // 1. Run the install migration
-	    if (!$this->db->tableExists(MapRecord::OldTableName))
+	    if (!$this->db->tableExists(MapRecord::OldTableName) && !$this->db->tableExists(MapRecord::TableName))
 	        (new Install())->safeUp();
 
 	    // 2. Upgrade the data

--- a/src/migrations/m190226_143809_craft3_upgrade.php
+++ b/src/migrations/m190226_143809_craft3_upgrade.php
@@ -2,6 +2,7 @@
 
 namespace ether\simplemap\migrations;
 
+use Craft;
 use craft\db\Migration;
 use craft\db\Query;
 use craft\db\Table;

--- a/src/migrations/m190226_143809_craft3_upgrade.php
+++ b/src/migrations/m190226_143809_craft3_upgrade.php
@@ -69,7 +69,7 @@ class m190226_143809_craft3_upgrade extends Migration
     private function _upgrade2 ()
     {
     	$mapService = SimpleMap::getInstance()->map;
-        $fieldsService = Craft::$app->getFields();
+		$fieldsService = Craft::$app->getFields();
 
     	// Delete the old plugin row
 	    $this->delete(Table::PLUGINS, ['handle' => 'simple-map']);
@@ -130,7 +130,7 @@ class m190226_143809_craft3_upgrade extends Migration
 				];
 
 				$newField = $fieldsService->createField([
-					'type'                 => MapField::class,
+					'type'                 => 'ether\simplemap\fields\MapField',
 					'id'                   => $field->id,
 					'groupId'              => $field->groupId,
 					'name'                 => $field->name,

--- a/src/migrations/m190226_143809_craft3_upgrade.php
+++ b/src/migrations/m190226_143809_craft3_upgrade.php
@@ -121,16 +121,7 @@ class m190226_143809_craft3_upgrade extends Migration
 
 				$oldSettings = Json::decodeIfJson($field->settings);
 
-				$newSettings = [
-					'lat'     => $oldSettings['lat'],
-					'lng'     => $oldSettings['lng'],
-					'zoom'    => $oldSettings['zoom'] ?? 15,
-					'country' => strtoupper($oldSettings['countryRestriction'] ?? '') ?: null,
-					'hideMap' => $oldSettings['hideMap'],
-				];
-
-				$newField = $fieldsService->createField([
-					'type'                 => 'ether\simplemap\fields\MapField',
+				$newField = new MapField([
 					'id'                   => $field->id,
 					'groupId'              => $field->groupId,
 					'name'                 => $field->name,
@@ -139,7 +130,12 @@ class m190226_143809_craft3_upgrade extends Migration
 					'searchable'           => $field->searchable,
 					'translationMethod'    => $field->translationMethod,
 					'translationKeyFormat' => $field->translationKeyFormat,
-					'settings'             => Json::encode($newSettings),
+
+					'lat'     => $oldSettings['lat'],
+					'lng'     => $oldSettings['lng'],
+					'zoom'    => $oldSettings['zoom'] ?? 15,
+					'country' => strtoupper($oldSettings['countryRestriction'] ?? '') ?: null,
+					'hideMap' => $oldSettings['hideMap'],
 				]);
 
 				$fieldsService->saveField($newField);

--- a/src/migrations/m190226_143809_craft3_upgrade.php
+++ b/src/migrations/m190226_143809_craft3_upgrade.php
@@ -68,6 +68,7 @@ class m190226_143809_craft3_upgrade extends Migration
     private function _upgrade2 ()
     {
     	$mapService = SimpleMap::getInstance()->map;
+        $fieldsService = Craft::$app->getFields();
 
     	// Delete the old plugin row
 	    $this->delete(Table::PLUGINS, ['handle' => 'simple-map']);


### PR DESCRIPTION
Fixes upgrade from craft 2, since install is already required because of the changed plugin name.

Running install followed by the migrations causes errors, because the maps table is already created.