### PR TITLE
Force Marker centre to be a float

### DIFF
--- a/src/models/Marker.php
+++ b/src/models/Marker.php
@@ -91,7 +91,7 @@ class Marker
 			return GeoService::latLngFromAddress($this->location);
 
 		if (!array_key_exists('lat', $this->location) || !array_key_exists('lng', $this->location))
-			return ['lat' => $this->location[0], 'lng' => $this->location[1]];
+			return ['lat' => (float)$this->location[0], 'lng' => (float)$this->location[1]];
 
 		return $this->location;
 	}


### PR DESCRIPTION
Fixes sometimes older map fields returning their coordinates in string format.

Changes proposed in this pull request:

- Forces the centre location in a Marker to come back as a float


**Before**


```json
[{"position":{"lat":"54.584500000","lng":"-5.702310000"},"label":"A"},{"position":{"lat":"54.632820000","lng":"-5.677030000"},"label":"B"},{"position":{"lat":"54.639390000","lng":"-5.664440000"},"label":"C"}]
```

**After** 

```json
[{"position":{"lat":54.57328168450693,"lng":-5.961975809186699},"label":"A"},{"position":{"lat":54.57516,"lng":-5.96089},"label":"B"},{"position":{"lat":54.57875,"lng":-5.97368},"label":"C"}]
```