### PR TITLE
Codegen fixes

### DIFF
--- a/src/integrations/graphql/MapPartsType.php
+++ b/src/integrations/graphql/MapPartsType.php
@@ -23,7 +23,7 @@ class MapPartsType
 
 	public static function getName (): string
 	{
-		return 'MapParts';
+		return 'Ether_MapParts';
 	}
 
 	public static function getFieldDefinitions (): array

--- a/src/integrations/graphql/MapType.php
+++ b/src/integrations/graphql/MapType.php
@@ -23,7 +23,7 @@ class MapType
 
 	public static function getName (): string
 	{
-		return 'Map';
+		return 'Ether_Map';
 	}
 
 	public static function getFieldDefinitions (): array


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds `Ether_` prefix to `Map` and `MapParts` schema types.

### Why?

When using [TypeScript GraphQL Codegen](https://graphql-code-generator.com/docs/plugins/typescript), the Ether Map type is exported as `Map`, which conflicts with a pre-existing `Map` interface.

![Screenshot 2020-09-04 at 09 36 54](https://user-images.githubusercontent.com/4851924/92219239-3597d400-ee92-11ea-9a7e-2feb6daa67b8.png)