### PR TITLE
Prevents control panel breaking error with What3worlds integration

### DIFF
--- a/src/services/What3WordsService.php
+++ b/src/services/What3WordsService.php
@@ -22,7 +22,7 @@ class What3WordsService
 
 	public static function convertLatLngToW3W ($lat, $lng)
 	{
-		return self::_geocoder()->convertTo3wa($lat, $lng)['words'];
+		return self::_geocoder()->convertTo3wa($lat, $lng)['words'] ?? false;
 	}
 
 	private static function _geocoder ()


### PR DESCRIPTION
This prevents a control-panel breaking error which may occur with the what3words integration.

Fixes #291.

Changes proposed in this pull request:

- Returns false to suppress ` yii\base\ErrorException: Trying to access array offset on value of type bool` error 