### PR TITLE
Add missing translation key

### DIFF
--- a/src/fields/MapField.php
+++ b/src/fields/MapField.php
@@ -476,6 +476,7 @@ class MapField extends Field implements PreviewableFieldInterface
 		$view->registerTranslations('simplemap', [
 			'Search for a location',
 			'Clear address',
+			'Full Address',
 			'Name / Number',
 			'Street Address',
 			'Town / City',


### PR DESCRIPTION
Fixes issue where the term "Full Address" is not translated in the CP field when using custom translations inside `/translations/<locale>/simplemap.php`.