### PR TITLE
Accept guzzle 7 as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "craftcms/cms": "^3.2.1",
     "mapkit/jwt": "^1.1.2",
     "geoip2/geoip2": "~2.0",
-    "guzzlehttp/guzzle": "^6.3.3",
+    "guzzlehttp/guzzle": "^6.3.3|^7.2.0",
     "what3words/w3w-php-wrapper": "3.*",
     "ext-openssl": "*",
     "ext-json": "*",


### PR DESCRIPTION
The latest version of Craft installs guzzle 7 by default, but simple map only accepts guzzle ^6.3.3. Updating this dependency would avoid the need to manually downgrade guzzle to use the plugin.

Fixes # .

Changes proposed in this pull request:

- 
- 
- 