### PR TITLE
Include referer header in Mapbox Geocoding request

### DIFF
--- a/src/services/GeoService.php
+++ b/src/services/GeoService.php
@@ -769,7 +769,11 @@ class GeoService extends Component
 				$url = str_replace('.json', rawurlencode(', ' . $country) . '.json', $url);
 		}
 
-		$data = (string) static::_client()->get($url)->getBody();
+		$data = (string) static::_client()->get($url, [
+            'headers' => [
+                'referer' => Craft::$app->urlManager->getHostInfo()
+            ]
+        ])->getBody();
 		$data = Json::decodeIfJson($data);
 
 		if (!is_array($data) || empty($data['features']))


### PR DESCRIPTION
Fixes Mapbox Forbidden issue #218.

Changes proposed in this pull request:

- Following the troubleshooting guide [here](https://docs.mapbox.com/accounts/guides/tokens/#troubleshooting-url-restrictions) include the correct referer header in case a Mapbox geocoding request is sent.