### PR TITLE
Change registerScript method to registerJsFile method in EmbedService.

### DIFF
--- a/src/services/EmbedService.php
+++ b/src/services/EmbedService.php
@@ -616,14 +616,13 @@ JS;
 			);
 		}
 
-		$view->registerScript(
-			'',
+		$view->registerJsFile(
+			$url,
+			$options,
+			'[]',
 			View::POS_END,
-			array_merge(
-				['src' => $url],
-				$options
-			),
-			md5($url)
+			true,
+			md5($url),
 		);
 	}
 


### PR DESCRIPTION
Fixes #340 .

Changes proposed in this pull request:

- Updating the registerScript method to be a registerJsFile method to avoid error on template cached maps.