### PR TITLE
Fix Google Maps api load order + provide an extra callback for devs to hook into

### DIFF
--- a/src/services/EmbedService.php
+++ b/src/services/EmbedService.php
@@ -105,6 +105,7 @@ class EmbedService extends Component
 	{
 		$view = Craft::$app->getView();
 		$callbackName = 'init_' . $options->id;
+		$loadedCallbackName =  $options->id . '_loaded';
 
 		$mapTypeId = match ($settings->mapTiles)
 		{
@@ -146,11 +147,6 @@ class EmbedService extends Component
 			'callback' => $callbackName,
 		]);
 
-		$this->_js(
-			'https://maps.googleapis.com/maps/api/js?' . $params,
-			['async' => '', 'defer' => '']
-		);
-
 		$js = <<<JS
 let {$options->id};
 
@@ -165,10 +161,15 @@ function {$callbackName} () {
 }
 JS;
 
+
+		$view->registerScript($js, View::POS_END);
+
+		$this->_js(
+			'https://maps.googleapis.com/maps/api/js?' . $params,
+			['async' => '', 'defer' => '', 'onload' => "typeof {$loadedCallbackName} != 'undefined' && {$loadedCallbackName}()"]
+		);
+
 		$css = $this->_getCss($options);
-
-
-		$view->registerJs($js, View::POS_END);
 		$css && $view->registerCss($css);
 
 		return '<div id="' . $options->id . '"></div>';


### PR DESCRIPTION
Fixes #294

Fixes the load order for Google Maps api. Since it uses a passed callback in the URL, the callback needs to be added first, hence changing to registerScript to force the order (Craft doesn't seem to have a mechanism to specify assets order except AssetBundles).

Also added an onload event to provide an extra callback with "onload" since the code already provides the callback to add the markers. By adding this callback, we are guaranteed that our extra code executes after the Google Maps API is loaded and that the initial callback is executed.