### PR TITLE
Fix syntax error when using older versions of PHP

### DIFF
--- a/src/services/EmbedService.php
+++ b/src/services/EmbedService.php
@@ -622,7 +622,7 @@ JS;
 			'[]',
 			View::POS_END,
 			true,
-			md5($url),
+			md5($url)
 		);
 	}
 


### PR DESCRIPTION
Fix syntax error when using older versions of PHP eg. 7.2