### PR TITLE
Typecast BaseLocation.php $config

### DIFF
--- a/src/models/BaseLocation.php
+++ b/src/models/BaseLocation.php
@@ -9,6 +9,7 @@
 namespace ether\simplemap\models;
 
 use craft\helpers\Json;
+use craft\helpers\Typecast;
 use Twig\Markup;
 use yii\base\Model;
 
@@ -44,6 +45,8 @@ abstract class BaseLocation extends Model
 
 	public function __construct ($config = [])
 	{
+		Typecast::properties(static::class, $config);
+		
 		parent::__construct($config);
 
 		if ($this->address === null)


### PR DESCRIPTION
Run the BaseLocation $config through the craft Typecast helper to address type errors when working with the map field on the front end. Craft automatically call this for any classes that extend the craft Model.php class, but not here as it extends the yii Model class directly.

Fixes https://github.com/ethercreative/simplemap/issues/379