### PR TITLE
Set proper referer for Mapbox if console request

### DIFF
--- a/src/services/GeoService.php
+++ b/src/services/GeoService.php
@@ -759,9 +759,13 @@ class GeoService extends Component
 				$url = str_replace('.json', rawurlencode(', ' . $country) . '.json', $url);
 		}
 
+		$referer = Craft::$app->getRequest()->getIsConsoleRequest()
+			? Craft::getAlias('@web')
+			: Craft::$app->urlManager->getHostInfo();
+
 		$data = (string) static::_client()->get($url, [
             'headers' => [
-                'referer' => Craft::$app->urlManager->getHostInfo()
+                'referer' => $referer,
             ]
         ])->getBody();
 		$data = Json::decodeIfJson($data);


### PR DESCRIPTION
Fixes #338

Changes proposed in this pull request:

- Set referer to web alias if the request is a console request
- Fallback to `Craft::$app->urlManager->getHostInfo()` if web request

This allows `_latLngFromAddress_Mapbox()` to be called from Feed Me and queue jobs without failing.