### PR TITLE
Add an ACF adapter for Google Map fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "ext-zlib": "*",
     "php": "^8.2"
   },
+  "require-dev": {
+    "craftcms/wp-import": "dev-main"
+  },
   "autoload": {
     "psr-4": {
       "ether\\simplemap\\": "src/"

--- a/src/SimpleMap.php
+++ b/src/SimpleMap.php
@@ -20,6 +20,8 @@ use craft\services\Gql;
 use craft\web\Application;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
+use craft\wpimport\Command as WpImportCommand;
+use ether\simplemap\acfadapters\GoogleMap as GoogleMapAcfAdapter;
 use ether\simplemap\fields\MapField as MapField;
 use ether\simplemap\integrations\feedme\FeedMeMaps;
 use ether\simplemap\integrations\graphql\MapPartsType;
@@ -138,6 +140,16 @@ class SimpleMap extends Plugin
 				Application::class,
 				Application::EVENT_INIT,
 				[$this, 'onApplicationInit']
+			);
+		}
+
+		if (class_exists(WpImportCommand::class)) {
+			Event::on(
+				WpImportCommand::class,
+				WpImportCommand::EVENT_REGISTER_ACF_ADAPTERS,
+				static function (RegisterComponentTypesEvent $event) {
+					$event->types[] = GoogleMapAcfAdapter::class;
+				}
 			);
 		}
 	}

--- a/src/acfadapters/GoogleMap.php
+++ b/src/acfadapters/GoogleMap.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Maps for Craft CMS
+ *
+ * @link      https://ethercreative.co.uk
+ * @copyright Copyright (c) 2024 Ether Creative
+ */
+
+namespace ether\simplemap\acfadapters;
+
+use craft\base\FieldInterface;
+use craft\wpimport\BaseAcfAdapter;
+use ether\simplemap\fields\MapField;
+
+/**
+ * Class GoogleMap
+ *
+ * @author  Ether Creative
+ * @author  Brandon Kelly
+ * @package ether\simplemap\acfadapters
+ */
+class GoogleMap extends BaseAcfAdapter
+{
+	public static function type(): string
+	{
+		return 'google_map';
+	}
+
+	public function create(array $data): FieldInterface
+	{
+		$field = new MapField();
+		if ($data['center_lat']) {
+			$field->lat = $data['center_lat'];
+		}
+		if ($data['center_lng']) {
+			$field->lng = $data['center_lng'];
+		}
+		if ($data['zoom']) {
+			$field->zoom = $data['zoom'];
+		}
+		return $field;
+	}
+
+	public function normalizeValue(mixed $value, array $data): mixed
+	{
+		return [
+			'address' => $value['address'],
+			'lat' => $value['lat'],
+			'lng' => $value['lng'],
+			'zoom' => $value['zoom'],
+			'parts' => [
+				'number' => $value['street_number'],
+				'address' => $value['street_name'],
+				'city' => $value['city'],
+				'postcode' => $value['post_code'],
+				'state' => $value['state'],
+				'country' => $value['country'],
+				'administrative_area_level_1' => $value['state'],
+				'locality' => $value['city'],
+				'postal_code' => $value['post_code'],
+				'route' => $value['street_name'],
+				'street_number' => $value['street_number'],
+			],
+		];
+	}
+}


### PR DESCRIPTION
Registers an ACF adapter for a forthcoming WordPress → Craft import script.

We’ll be making the script public on Tuesday at 10am PT. If this is pulled in and tagged by then, we can mention it in the blog post :)