### PR TITLE
Fixed an issue querying address field from non-primary site

### DIFF
--- a/src/services/MapService.php
+++ b/src/services/MapService.php
@@ -189,7 +189,6 @@ class MapService extends Component
 			'and',
 			'[[elements.id]] = [[' . $alias . '.ownerId]]',
 			'[[elements.dateDeleted]] IS NULL',
-			'[[elements_sites.siteId]] = [[' . $alias . '.ownerSiteId]]',
 			'[[' . $alias . '.fieldId]] = ' . $field->id,
 		];
 


### PR DESCRIPTION
### Problem  
Location queries using the map field fail on non-primary sites in multi-site Craft CMS installations. This is due to a strict `JOIN` condition that matches `elements_sites.siteId` to `ownerSiteId`, preventing access to map data saved on different sites.

### Root Cause  
In `MapService::modifyElementsQuery()`, the `JOIN` condition includes:  
```sql  
[[elements_sites.siteId]] = [[alias.ownerSiteId]]  
```
This breaks location queries when:  
- Map data is saved on **Site A** (`ownerSiteId = 1`)  
- A query runs on **Site B** (`siteId = 2`)  
→ No results are returned since `1 ≠ 2`.

### Solution  
- **Removed** the strict site ID match from the `JOIN` condition.  
- **Preserved** integrity by matching:  
  - Element ID: `[[elements.id]] = [[alias.ownerId]]`  
  - Field ID: `[[alias.fieldId]] = field->id`  
  - Excludes deleted elements: \`[[elements.dateDeleted]] IS NULL\`  

### Files Changed  
- `src/services/MapService.php`: Modified the `JOIN` condition in `modifyElementsQuery()`


### Impact  
This fix eliminates the need for complex workarounds in multi-site templates and makes the plugin's location query functionality work as expected across all sites in a Craft CMS multi-site setup.