### PR TITLE
fix: add is_object check

### DIFF
--- a/src/models/Map.php
+++ b/src/models/Map.php
@@ -64,7 +64,7 @@ class Map extends BaseLocation
 
 	public function __get ($name)
 	{
-		$isPart = property_exists($this->parts, $name) || $name === 'streetAddress';
+		$isPart = (is_object($this->parts) && property_exists($this->parts, $name)) || $name === 'streetAddress';
 
 		if (in_array($name, PartsLegacy::$legacyKeys) && !$isPart)
 			return null;
@@ -79,7 +79,7 @@ class Map extends BaseLocation
 		try
 		{
 			if (
-				property_exists($this->parts, $name) ||
+				(is_object($this->parts) && property_exists($this->parts, $name)) ||
 				$name === 'streetAddress' ||
 				in_array($name, PartsLegacy::$legacyKeys)
 			) return true;


### PR DESCRIPTION
Importing via Feed me throws following error:
`An exception has been thrown during the rendering of a template ("property_exists(): Argument #1 ($object_or_class) must be of type object|string, array given")` on lines where the property_exists function is used.

Changes proposed in this pull request:

- Double-check if parts is an object

**Note**: this is a quick fix we did to make it work on a project, there might other fixes needed in the FeedMe mapper