### PR TITLE
Add referer header to Nominatim requests (v4)

### DIFF
--- a/src/services/GeoService.php
+++ b/src/services/GeoService.php
@@ -21,6 +21,7 @@ use ether\simplemap\SimpleMap;
 use GuzzleHttp\Client;
 use Mapkit\JWT;
 use Exception;
+use function GuzzleHttp\default_user_agent;
 
 /**
  * Class GeoService
@@ -763,13 +764,9 @@ class GeoService extends Component
 				$url = str_replace('.json', rawurlencode(', ' . $country) . '.json', $url);
 		}
 
-		$referer = Craft::$app->getRequest()->getIsConsoleRequest()
-			? Craft::getAlias('@web')
-			: Craft::$app->urlManager->getHostInfo();
-
 		$data = (string) static::_client()->get($url, [
             'headers' => [
-                'referer' => $referer,
+                'referer' => static::_referer(),
             ]
         ])->getBody();
 		$data = Json::decodeIfJson($data);
@@ -796,13 +793,10 @@ class GeoService extends Component
 				$url .= '&country=' . rawurlencode($country);
 		}
 
-		$referer = Craft::$app->getRequest()->getIsConsoleRequest()
-			? Craft::getAlias('@web')
-			: Craft::$app->urlManager->getHostInfo();
-
 		$data = (string) static::_client()->get($url, [
 			'headers' => [
-				'referer' => $referer
+				'referer' => static::_referer(),
+				'user-agent' => static::_userAgent(),
 			]
 		])->getBody();
 		$data = Json::decodeIfJson($data);
@@ -891,13 +885,10 @@ class GeoService extends Component
 		$url .= '&accept-language=' . Craft::$app->locale->getLanguageID();
 		$url .= '&lat=' . rawurlencode($lat) . '&lon=' . rawurldecode($lng);
 
-		$referer = Craft::$app->getRequest()->getIsConsoleRequest()
-			? Craft::getAlias('@web')
-			: Craft::$app->urlManager->getHostInfo();
-
 		$data = (string) static::_client()->get($url, [
 			'headers' => [
-				'referer' => $referer
+				'referer' => static::_referer(),
+				'user-agent' => static::_userAgent(),
 			]
 		])->getBody();
 		$data = Json::decodeIfJson($data);
@@ -928,6 +919,21 @@ class GeoService extends Component
 			$client = Craft::createGuzzleClient();
 
 		return $client;
+	}
+
+	private static function _referer ()
+	{
+		return Craft::$app->getRequest()->getIsConsoleRequest()
+			? Craft::getAlias('@web')
+			: Craft::$app->urlManager->getHostInfo();
+	}
+
+	private static function _userAgent ()
+	{
+		// User agent form based on Craft::createGuzzleClient
+		return 'Craft/' . Craft::$app->getVersion()
+			. ' ' . default_user_agent()
+			. ' ' . static::_referer();
 	}
 
 	private static function _validateCountryCode (string $code): bool

--- a/src/services/GeoService.php
+++ b/src/services/GeoService.php
@@ -796,7 +796,15 @@ class GeoService extends Component
 				$url .= '&country=' . rawurlencode($country);
 		}
 
-		$data = (string) static::_client()->get($url)->getBody();
+		$referer = Craft::$app->getRequest()->getIsConsoleRequest()
+			? Craft::getAlias('@web')
+			: Craft::$app->urlManager->getHostInfo();
+
+		$data = (string) static::_client()->get($url, [
+			'headers' => [
+				'referer' => $referer
+			]
+		])->getBody();
 		$data = Json::decodeIfJson($data);
 
 		if (!is_array($data) || empty($data))
@@ -883,7 +891,15 @@ class GeoService extends Component
 		$url .= '&accept-language=' . Craft::$app->locale->getLanguageID();
 		$url .= '&lat=' . rawurlencode($lat) . '&lon=' . rawurldecode($lng);
 
-		$data = (string) static::_client()->get($url)->getBody();
+		$referer = Craft::$app->getRequest()->getIsConsoleRequest()
+			? Craft::getAlias('@web')
+			: Craft::$app->urlManager->getHostInfo();
+
+		$data = (string) static::_client()->get($url, [
+			'headers' => [
+				'referer' => $referer
+			]
+		])->getBody();
 		$data = Json::decodeIfJson($data);
 
 		if (!is_array($data) || empty($data) || array_key_exists('error', $data))


### PR DESCRIPTION
Per the [Nominatim usage policy][1], all requests should have an identifying Referer or User-Agent header (quoted below). Using the host name, as we already do for Mapbox requests, should be sufficient to satisfy the requirement while avoiding the need for additional settings.

> Provide a valid HTTP Referer or User-Agent identifying the
> application (stock User-Agents as set by http libraries will not do).

[1]: https://operations.osmfoundation.org/policies/nominatim/

Based on a recommendation from an openstreetmap.org system administrator, I also added the identifier to the User-Agent header. My inference was that they block requests using it and having an app identifier would make it less likely we are blocked by another user that happens to be using the same User-Agent.