### PR TITLE
Allow override for Nominatim base URL (v4)

### DIFF
--- a/docs/getting-started/config.md
+++ b/docs/getting-started/config.md
@@ -179,8 +179,14 @@ return [
 #### `disablePopulateMissingFieldData`
 _Default: `false`_
 
-Will disable the automatic population of missing field data. This can be useful 
+Will disable the automatic population of missing field data. This can be useful
 in preventing API spam when importing lots of map data.
+
+#### `nominatimBaseUrl`
+_Default: `'https://nominatim.openstreetmap.org'`_
+
+The base URL for the Nominatim service. Override to use a self-hosted instance
+or a proxy.
 
 #### `geoLocationService`
 _Default: `GeoLocationService::None`_

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -58,6 +58,12 @@ class Settings extends Model
 	 */
 	public bool $disablePopulateMissingFieldData = false;
 
+	/**
+	 * @var string The base URL for the Nominatim service. Override to use a
+	 *   self-hosted instance or a proxy.
+	 */
+	public string $nominatimBaseUrl = 'https://nominatim.openstreetmap.org';
+
 	// Properties: w3w
 	// -------------------------------------------------------------------------
 

--- a/src/services/GeoService.php
+++ b/src/services/GeoService.php
@@ -599,7 +599,7 @@ class GeoService extends Component
 				$address, $country
 			),
 			GeoEnum::Nominatim => static::_latLngFromAddress_Nominatim(
-				$address, $country
+				$address, $country, $settings->nominatimBaseUrl
 			),
 			default => throw new Exception(
 				'Unknown geo-coding service: ' . $settings->geoService
@@ -638,7 +638,7 @@ class GeoService extends Component
 				$lat, $lng
 			),
 			GeoEnum::Nominatim => static::_addressFromLatLng_Nominatim(
-				$lat, $lng
+				$lat, $lng, $settings->nominatimBaseUrl
 			),
 			default => throw new Exception(
 				'Unknown geo-coding service: ' . $settings->geoService
@@ -783,9 +783,9 @@ class GeoService extends Component
 		];
 	}
 
-	private static function _latLngFromAddress_Nominatim ($address, $country): ?array
+	private static function _latLngFromAddress_Nominatim ($address, $country, $baseUrl): ?array
 	{
-		$url = 'https://nominatim.openstreetmap.org/search?format=jsonv2&limit=1';
+		$url = $baseUrl . '/search?format=jsonv2&limit=1';
 		$url .= '&accept-language=' . Craft::$app->locale->getLanguageID();
 		$url .= '&q=' . rawurlencode($address);
 		if ($country !== null)
@@ -877,9 +877,9 @@ class GeoService extends Component
 		];
 	}
 
-	private static function _addressFromLatLng_Nominatim ($lat, $lng): ?array
+	private static function _addressFromLatLng_Nominatim ($lat, $lng, $baseUrl): ?array
 	{
-		$url = 'https://nominatim.openstreetmap.org/reverse?format=jsonv2&limit=1&addressdetails=1';
+		$url = $baseUrl . '/reverse?format=jsonv2&limit=1&addressdetails=1';
 		$url .= '&accept-language=' . Craft::$app->locale->getLanguageID();
 		$url .= '&lat=' . rawurlencode($lat) . '&lon=' . rawurldecode($lng);
 


### PR DESCRIPTION
Nominatim can be self-hosted or one might want to use a proxy, for example to implement rate limiting. To support such use cases, I made the Nominatim base URL a setting. The default value is the same origin as was hard-coded in the GeoService requests, so this feature is backwards compatible.

Notably, being able to use a rate-limiting proxy helps users ensure they adhere to [Nominatim's usage policy][1].

[1]: https://operations.osmfoundation.org/policies/nominatim/
